### PR TITLE
make build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,11 @@ loom {
 val minecraftVersion: String by project
 val fabricLoaderVersion: String by project
 val yaclVersion: String by project
+val yarnMappings: String by project
 
 dependencies {
     minecraft("com.mojang:minecraft:$minecraftVersion")
-    mappings("net.fabricmc:yarn:$minecraftVersion+build.+:v2")
+    mappings("net.fabricmc:yarn:$minecraftVersion+$yarnMappings")
     modImplementation("net.fabricmc:fabric-loader:$fabricLoaderVersion")
 
     modImplementation("dev.isxander:yet-another-config-lib:$yaclVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,9 @@
 org.gradle.jvmargs=-Xmx3G
 
-minecraftVersion=1.19.3-pre2
-fabricLoaderVersion=0.14.10
-yaclVersion=2.0.0+1.19.3-SNAPSHOT
+minecraftVersion=1.19.3
+fabricLoaderVersion=0.14.19
+yaclVersion=2.2.0
+yarnMappings=build.5
 
 modId=options-remastered
 modName=Options Remastered

--- a/src/main/java/dev/isxander/optionsremastered/VideoOptionsCategory.java
+++ b/src/main/java/dev/isxander/optionsremastered/VideoOptionsCategory.java
@@ -86,9 +86,10 @@ public class VideoOptionsCategory extends ConfigCategorySupplier {
                         .option(OptionsRemastered.minecraftOption(options.getCloudRenderMode(), CloudRenderMode.class)
                                 .controller(EnumController::new)
                                 .build())
-                        .option(OptionsRemastered.minecraftOption(options.getAo(), AoMode.class)
-                                .controller(EnumController::new)
-                                .build())
+                        // TODO: Find AoMode symbol and correct it here
+                        // .option(OptionsRemastered.minecraftOption(options.getAo(), AoMode.class)
+                        //         .controller(EnumController::new)
+                        //         .build())
                         .option(OptionsRemastered.minecraftOption(options.getEntityShadows(), boolean.class)
                                 .controller(TickBoxController::new)
                                 .build())

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
   "accessWidener": "options-remastered.accesswidener",
   "depends": {
     "fabricloader": ">=0.14.10",
-    "minecraft": "~1.19.3",
+    "minecraft": ">=1.19.3",
     "java": ">=17",
     "yet-another-config-lib": "2.x.x"
   }


### PR DESCRIPTION
* stopped targeting 1.19.3 pre-release
* fixed yarnMapping (no longer hardcoded into build.gradle)
* corrected fabric.mod.json to use `>=` instead of `~`
* Disable `AoMode` as symbol was not found (code exists, just //'ed)